### PR TITLE
Add searching in parameter names as well.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -30,7 +30,12 @@ fn rank_item<'a>(
         candidate = &abbr;
     }
 
-    if pattern.chars().count() < 2 || !candidate.starts_with(&pattern[0..2]) {
+    let mut count = pattern.chars().count();
+    if count > 2 {
+        count = 2;
+    }
+
+    if !candidate.starts_with(&pattern[0..count]) {
         return None;
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,7 @@ use std::vec::Vec;
 
 #[derive(Serialize, Deserialize, Debug)]
 struct CompletionItem {
-    abbr: String,
+    word: String,
 
     #[serde(flatten)]
     rest: HashMap<String, Value>,
@@ -25,12 +25,16 @@ fn rank_item<'a>(
     pattern: &str,
     priority: i64,
 ) -> Option<Ranked<'a, CompletionItem>> {
+    let mut candidate: String = item.word.clone();
     let prefix: &str = &pattern[0..2];
-    if !item.abbr.starts_with(prefix) {
+    if let Some(Value::String(abbr)) = item.rest.get("abbr") {
+        candidate = abbr.clone();
+    }
+    if !candidate.starts_with(prefix) {
         return None;
     }
 
-    fuzzy_match(&item.abbr, &pattern).map(|rank| Ranked {
+    fuzzy_match(&candidate, &pattern).map(|rank| Ranked {
         item,
         rank,
         priority,

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,6 +25,11 @@ fn rank_item<'a>(
     pattern: &str,
     priority: i64,
 ) -> Option<Ranked<'a, CompletionItem>> {
+    let prefix: &str = &pattern[0..2];
+    if !item.abbr.starts_with(prefix) {
+        return None;
+    }
+
     fuzzy_match(&item.abbr, &pattern).map(|rank| Ranked {
         item,
         rank,

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,8 +30,7 @@ fn rank_item<'a>(
         candidate = &abbr;
     }
 
-    let prefix: &str = &pattern[0..2];
-    if !candidate.starts_with(prefix) {
+    if pattern.chars().count() < 2 || !candidate.starts_with(&pattern[0..2]) {
         return None;
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,11 +25,12 @@ fn rank_item<'a>(
     pattern: &str,
     priority: i64,
 ) -> Option<Ranked<'a, CompletionItem>> {
-    let mut candidate: String = item.word.clone();
-    let prefix: &str = &pattern[0..2];
+    let mut candidate: &String = &item.word;
     if let Some(Value::String(abbr)) = item.rest.get("abbr") {
-        candidate = abbr.clone();
+        candidate = &abbr;
     }
+
+    let prefix: &str = &pattern[0..2];
     if !candidate.starts_with(prefix) {
         return None;
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,7 @@ use std::vec::Vec;
 
 #[derive(Serialize, Deserialize, Debug)]
 struct CompletionItem {
-    word: String,
+    abbr: String,
 
     #[serde(flatten)]
     rest: HashMap<String, Value>,
@@ -25,7 +25,7 @@ fn rank_item<'a>(
     pattern: &str,
     priority: i64,
 ) -> Option<Ranked<'a, CompletionItem>> {
-    fuzzy_match(&item.word, &pattern).map(|rank| Ranked {
+    fuzzy_match(&item.abbr, &pattern).map(|rank| Ranked {
         item,
         rank,
         priority,


### PR DESCRIPTION
I'm writing mostly Swift code. And especially the code provided by apple follows a pattern where the function name is equal and the parameter names differ:
```swift
func tableView(_ t: UITableView, didDoSomething: Bool)
func tableView(_ t: UITableView, willDoSomething: Bool)
```

As you're comparing `word` the fuzzy matching would only match on `tableView`. So `tabdiddo` wouldn't match anything.

In this PR I've changed the Rust executable to compare `abbr` instead of `word`. If the `abbr` isn't available `word` is still used.

While the matching worked well after typing a longer search it didn't work well for short strings, so I added the requirement of the first two chars matching.

I don't expect you to merge this PR but maybe you see a way to integrate this change as a configuration. (Bear with me, this is the first Rust I've written 🙂)